### PR TITLE
Add missing credentials param

### DIFF
--- a/scripts/examples/authentication/auth0-resource-owner-password.js
+++ b/scripts/examples/authentication/auth0-resource-owner-password.js
@@ -48,5 +48,5 @@ function getOptionalParamsNames(){
 }
 
 function getCredentialsParamsNames(){
-	return ["client_id", "client_secret", "password"];
+	return ["client_id", "client_secret", "username", "password"];
 }


### PR DESCRIPTION
Add missing credentials param ("username") that's in use in requestBody to the getCredentialsParameters function.