### PR TITLE
fix Auth0 Resource Owner Password yml

### DIFF
--- a/configs/authentication/stackhawk-auth0-resource-owner-password.yml
+++ b/configs/authentication/stackhawk-auth0-resource-owner-password.yml
@@ -7,11 +7,11 @@ app:
   authentication:
     loggedInIndicator: "HTTP.*2[0-9][0-9]\\s*O[kK](\\s*)|HTTP.*3[0-9][0-9].*"
     loggedOutIndicator: "HTTP.*4[0-9][0-9](\\s*)Unauthorized.*" 
-     # -- Customized Configuration for Authentication Scripting --
+    # -- Customized Configuration for Authentication Scripting --
     # Specify the parameters required for POSTing to the token URL
-    # parementers and credentials generally function the same, only credentials will be redacted throughout the StackHawk platform.
+    # parameters and credentials generally function the same; only credentials will be redacted throughout the StackHawk platform.
     script:
-      name: auth.js
+      name: auth0-resource-owner-password.js
       parameters:
         issuer: https://${YOUR_AUTH0_DOMAIN}.us.auth0.com/oauth/token
         grant_type: password
@@ -21,16 +21,20 @@ app:
         client_secret: xxxXXXXxxxxXXXXxxxx ## \${CLIENT_SECRET}
         username: test@email.com
         password: hawkScan1
-
+    sessionScript:
+      name: access-token-session.js 
     testPath:
       path: /api/external
       success: '.*200.*'
- 
-  # The location of the script directory should be relative to the stackhawk.yml file.
-  hawkAddOn:
+    # The location of the script directory should be relative to the stackhawk.yml file.
+hawkAddOn:
   scripts:
-    - name: auth.js
+    - name: auth0-resource-owner-password.js
       language: JAVASCRIPT
       type: authentication
       path: scripts
+    - name: access-token-session.js
+      type: session
+      path: scripts
+      language: JAVASCRIPT
   


### PR DESCRIPTION
Update Auth0 Resource Owner Password flow example yml:

- remove indentation of hawkAddOn.yml
- add session script (as is, validation fails with Missing property, should have exactly 1 property from [cookieAuthorization, tokenAuthorization, sessionScript])
- tweak formatting