### PR TITLE
Replace bearerName with tokenType in tokenAuthorization examples

### DIFF
--- a/configs/authentication/stackhawk-auth-external-token-header.yml
+++ b/configs/authentication/stackhawk-auth-external-token-header.yml
@@ -25,7 +25,7 @@ app:
       value: Authorization
       # The token type when using the Authorization header as is being used here.
       # Bearer is the most common value but custom names like "JWT" or "token" are sometimes required.
-      bearerName: Bearer
+      tokenType: Bearer
     loggedInIndicator: "\\QMy profile\\E"
     loggedOutIndicator: "\\QUsername: \\E"
     # The testPath configuration is used to confirm scanning as an authenticated user is configured successfully.

--- a/configs/authentication/stackhawk-auth-json-token.yml
+++ b/configs/authentication/stackhawk-auth-json-token.yml
@@ -44,7 +44,7 @@ app:
       value: Authorization
       # The token type when using the Authorization header as is being used here.
       # Bearer is the most common value but custom names like "JWT" or "token" are sometimes required.
-      bearerName: Bearer
+      tokenType: Bearer
     # The testPath configuration is used to confirm scanning as an authenticated user is configured successfully.
     testPath:
       # The type is either HEADER or BODY and informs the success or fail regex of what part of the response to match against.


### PR DESCRIPTION
Replace tokenAuthorization.bearerName (which doesn't work as of 3.1) with tokenType (which does) in the examples repo.