### PR TITLE
Update stackhawk-auth-external-token-header.yml

### DIFF
--- a/configs/authentication/stackhawk-auth-external-token-header.yml
+++ b/configs/authentication/stackhawk-auth-external-token-header.yml
@@ -23,9 +23,6 @@ app:
       type: HEADER
       # The name of the header that the token will be passed with requests authenticated routes.
       value: Authorization
-      # The token type when using the Authorization header as is being used here.
-      # Bearer is the most common value but custom names like "JWT" or "token" are sometimes required.
-      bearerName: Bearer
     loggedInIndicator: "\\QMy profile\\E"
     loggedOutIndicator: "\\QUsername: \\E"
     # The testPath configuration is used to confirm scanning as an authenticated user is configured successfully.


### PR DESCRIPTION
update example: auth-external-token-header.yml
* `bearerName` is not a field on tokenAuthorization