### PR TITLE
Auth script - AD client credentials with certificate

### DIFF
--- a/configs/authentication/azure-ad-client-credential-certificate.kts
+++ b/configs/authentication/azure-ad-client-credential-certificate.kts
@@ -1,0 +1,139 @@
+import org.apache.commons.httpclient.URI
+import org.apache.log4j.LogManager
+import org.parosproxy.paros.network.HttpHeader
+import org.parosproxy.paros.network.HttpMessage
+import org.parosproxy.paros.network.HttpRequestHeader
+import org.zaproxy.zap.authentication.AuthenticationHelper
+import org.zaproxy.zap.authentication.GenericAuthenticationCredentials
+import org.zaproxy.zap.network.HttpRequestBody
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.security.MessageDigest
+import java.security.cert.Certificate
+import java.security.cert.CertificateFactory
+import java.util.Locale
+import javax.xml.bind.DatatypeConverter
+import com.nimbusds.jwt.JWTClaimsSet
+import java.util.Date
+import com.nimbusds.jose.JWSHeader
+import com.nimbusds.jose.JWSAlgorithm
+import com.nimbusds.jose.JOSEObjectType
+import com.nimbusds.jose.util.Base64URL
+import com.nimbusds.jwt.SignedJWT
+import java.net.URLEncoder
+
+val logger = LogManager.getLogger("AAD-CC-Auth-Script")
+
+// This function is called before a scan is started and when the loggedOutIndicator is matched indicating re-authentication is needed.
+fun authenticate(
+    helper: AuthenticationHelper,
+    paramsValues: Map<String, String>,
+    credentials: GenericAuthenticationCredentials
+): HttpMessage {
+    logger.info("AAD Client Credentials Authentication: Go!")
+
+    val baseUrl = "https://login.microsoftonline.com"
+    val tenant = paramsValues["tenant"]
+    val scope = paramsValues["scope"]
+    val clientId = credentials.getParam("clientId")
+    val grantType = "client_credentials"
+    val certThumbprint = paramsValues["cert_thumbprint"]
+    val openidConfigEndpoint = "${baseUrl}/${tenant}/v2.0/.well-known/openid-configuration"
+    val tokenEndpoint = "${baseUrl}/${tenant}/oauth2/v2.0/token"
+    val assertionType = URLEncoder.encode("urn:ietf:params:oauth:client-assertion-type:jwt-bearer", "UTF-8")
+    val client_assertion = getJwtToken(tokenEndpoint, clientId, certThumbprint!!)
+    val authRequestBody = "client_id=${clientId}&client_assertion_type=${assertionType}&grant_type=${grantType}&scope=${scope}&client_assertion=${client_assertion}"
+
+    logger.info("OpenID Configuration Endpoint: $openidConfigEndpoint")
+    logger.info("Token Endpoint: $tokenEndpoint")
+
+    val msg = helper.prepareMessage()
+    msg.requestHeader = HttpRequestHeader(
+        HttpRequestHeader.POST,
+        URI(tokenEndpoint, false),
+        HttpHeader.HTTP11
+    )
+    msg.requestHeader.setHeader("Content-Type", "application/x-www-form-urlencoded")
+    msg.requestHeader.setHeader("Accept", "application/json")
+    msg.requestHeader.setHeader("Cache-control", "no-cache")
+    msg.requestBody = HttpRequestBody(authRequestBody)
+    msg.requestHeader.contentLength = msg.requestBody.length()
+
+    helper.sendAndReceive(msg)
+    logger.info("Auth Request:\n=== REQUEST HEADERS ===\n${msg.requestHeader}\n=== REQUEST BODY ===\n${msg.requestBody}\n")
+    logger.info("Auth Response:\n=== RESPONSE HEADERS ===\n${msg.responseHeader}\n=== RESPONSE BODY ===\n${msg.responseBody}\n")
+
+    return msg
+}
+
+// The required parameter names for your script, your script will throw an error if these are not supplied in the script.parameters configuration.
+// Add these parameters to your HawkScan configuration file under app.authentication.script.parameters.
+fun getRequiredParamsNames(): Array<String> {
+    /**
+     * @return
+     *      tenant: The directory tenant that you want to log the user into. The tenant can be in GUID or friendly name format
+     *      scope:  A space-separated list of scopes, or permissions, that the app requires
+     */
+    return arrayOf("tenant", "scope", "audience_url", "cert_thumbprint")
+}
+
+// The required credential parameters, your script will throw an error if these are not supplied in the script.credentials configuration.
+// Add these credential parameters to your HawkScan configuration file under app.authentication.script.credentials.
+fun getCredentialsParamsNames(): Array<String> {
+    /**
+     * @return
+     *      clientId:       The Application (client) ID that the Azure portal - App registrations page assigned to your app
+     *      clientSecret:   The client secret that you generated for your app in the app registration portal
+     */
+    return arrayOf("clientId")
+}
+
+// Add these optional parameters to your HawkScan configuration file under app.authentication.script.parameters.
+fun getOptionalParamsNames(): Array<String> {
+    return arrayOf()
+}
+
+
+fun getJwtToken(aud : String, iss : String, x5t : String) : Base64URL {
+    val nbf  = Date()
+    val iat = nbf
+    //Add 5 mintues
+    val exp = Date(nbf.time + (5 * 60 * 1000))
+    val jwtId = "Testing"
+    val claimseSet = JWTClaimsSet.Builder()
+        .subject(iss)
+        .issuer(iss)
+        .notBeforeTime(nbf)
+        .issueTime(iat)
+        .expirationTime(exp)
+        .jwtID(jwtId)
+        .audience(aud)
+        .build()
+
+    val typ = "JWT"
+
+    val header = JWSHeader.Builder(JWSAlgorithm.RS256).type(JOSEObjectType(typ)).x509CertThumbprint(Base64URL(x5t)).build()
+
+    val jwt = SignedJWT(header, claimseSet)
+
+    return jwt.signature
+}
+
+
+fun getThumbrintFromCert(certPath : String) : String {
+    val certificateFactory = CertificateFactory.getInstance("X.509")
+    val certStream = ByteArrayInputStream(File(certPath).readBytes())
+    val cert: Certificate = certificateFactory.generateCertificate(certStream)
+    val thumbrint = getThumbprint(cert)
+    return thumbrint
+}
+
+
+fun getThumbprint(cert: Certificate): String {
+    val md = MessageDigest.getInstance("SHA-1")
+    val der: ByteArray = cert.getEncoded()
+    md.update(der)
+    val digest = md.digest()
+    val digestHex = DatatypeConverter.printHexBinary(digest)
+    return digestHex.lowercase(Locale.getDefault())
+}

--- a/configs/authentication/stackhawk-auth-azure-ad-client-credentials-certificate.yml
+++ b/configs/authentication/stackhawk-auth-azure-ad-client-credentials-certificate.yml
@@ -21,6 +21,7 @@ app:
         cert_path: path/to/certfile.pem # Path to the certificate file in PEM format, e.g. `openssl pkcs12 -in {yourSigningCert.pfx} -clcerts -nokeys -out yourcert.pem`
         tenant: ${AAD_TENANT} # The directory tenant that you want to log the user into. The tenant can be in GUID or friendly name format
 #        scope: ${AAD_SCOPE} # OPTIONAL resource identifier (application ID URI), affixed with the .default suffix, e.g. https://graph.microsoft.com/.default
+        kid: ${AAD_KID}
       credentials:
         clientId: ${AAD_CLIENT_ID} # The Application (client) ID that the Azure portal App registrations page assigned to your app
         pem_key: ${AAD_PEM_KEY} # The client key in PEM format, e.g. `openssl pkcs12 -in {yourSigningCert.pfx} -nocerts -nodes | openssl rsa`

--- a/configs/authentication/stackhawk-auth-azure-ad-client-credentials-certificate.yml
+++ b/configs/authentication/stackhawk-auth-azure-ad-client-credentials-certificate.yml
@@ -21,7 +21,7 @@ app:
         tenant: ${AAD_TENANT} # The directory tenant that you want to log the user into. The tenant can be in GUID or friendly name format
         scope: ${AAD_SCOPE} # The resource identifier (application ID URI) of the resource you want, affixed with the .default suffix, e.g. https://graph.microsoft.com/.default
         cert_thumbprint : ${AAD_CERT_THUMBPRINT} # Base64url-encoded SHA-1 thumbprint of the X.509 certificate's DER encoding. For example, given an X.509 certificate hash of 84E05C1D98BCE3A5421D225B140B36E86A3D5534 (Hex), the x5t claim would be hOBcHZi846VCHSJbFAs26Go9VTQ (Base64url).
-        cert_path: /path/to/cert
+        pem_key: ${PEM_KEY}
       credentials:
         clientId: ${AAD_CLIENT_ID} # The Application (client) ID that the Azure portal App registrations page assigned to your app
 

--- a/configs/authentication/stackhawk-auth-azure-ad-client-credentials-certificate.yml
+++ b/configs/authentication/stackhawk-auth-azure-ad-client-credentials-certificate.yml
@@ -21,7 +21,6 @@ app:
         cert_path: path/to/certfile.pem # Path to the certificate file in PEM format, e.g. `openssl pkcs12 -in {yourSigningCert.pfx} -clcerts -nokeys -out yourcert.pem`
         tenant: ${AAD_TENANT} # The directory tenant that you want to log the user into. The tenant can be in GUID or friendly name format
 #        scope: ${AAD_SCOPE} # OPTIONAL resource identifier (application ID URI), affixed with the .default suffix, e.g. https://graph.microsoft.com/.default
-        kid: ${AAD_KID}
       credentials:
         clientId: ${AAD_CLIENT_ID} # The Application (client) ID that the Azure portal App registrations page assigned to your app
         pem_key: ${AAD_PEM_KEY} # The client key in PEM format, e.g. `openssl pkcs12 -in {yourSigningCert.pfx} -nocerts -nodes | openssl rsa`

--- a/configs/authentication/stackhawk-auth-azure-ad-client-credentials-certificate.yml
+++ b/configs/authentication/stackhawk-auth-azure-ad-client-credentials-certificate.yml
@@ -21,9 +21,10 @@ app:
         tenant: ${AAD_TENANT} # The directory tenant that you want to log the user into. The tenant can be in GUID or friendly name format
         scope: ${AAD_SCOPE} # The resource identifier (application ID URI) of the resource you want, affixed with the .default suffix, e.g. https://graph.microsoft.com/.default
         cert_thumbprint : ${AAD_CERT_THUMBPRINT} # Base64url-encoded SHA-1 thumbprint of the X.509 certificate's DER encoding. For example, given an X.509 certificate hash of 84E05C1D98BCE3A5421D225B140B36E86A3D5534 (Hex), the x5t claim would be hOBcHZi846VCHSJbFAs26Go9VTQ (Base64url).
-        pem_key: ${PEM_KEY}
+        cert_path: /path/to/cert
       credentials:
         clientId: ${AAD_CLIENT_ID} # The Application (client) ID that the Azure portal App registrations page assigned to your app
+        pem_key: ${PEM_KEY}
 
     # AuthZ Settings
     tokenExtraction:

--- a/configs/authentication/stackhawk-auth-azure-ad-client-credentials-certificate.yml
+++ b/configs/authentication/stackhawk-auth-azure-ad-client-credentials-certificate.yml
@@ -20,11 +20,10 @@ app:
       parameters:
         tenant: ${AAD_TENANT} # The directory tenant that you want to log the user into. The tenant can be in GUID or friendly name format
         scope: ${AAD_SCOPE} # The resource identifier (application ID URI) of the resource you want, affixed with the .default suffix, e.g. https://graph.microsoft.com/.default
-        cert_thumbprint : ${AAD_CERT_THUMBPRINT} # Base64url-encoded SHA-1 thumbprint of the X.509 certificate's DER encoding. For example, given an X.509 certificate hash of 84E05C1D98BCE3A5421D225B140B36E86A3D5534 (Hex), the x5t claim would be hOBcHZi846VCHSJbFAs26Go9VTQ (Base64url).
-        cert_path: /path/to/cert
+        cert_path: /path/to/cert # Path to the certificate file in PEM format, e.g. `openssl pkcs12 -in {yourfile.pfx} -clcerts -nokeys -out yourcert.pem`
       credentials:
         clientId: ${AAD_CLIENT_ID} # The Application (client) ID that the Azure portal App registrations page assigned to your app
-        pem_key: ${PEM_KEY}
+        pem_key: ${PEM_KEY} # The client key in PEM format, e.g. `openssl pkcs12 -in {yourfile.pfx} -nocerts -nodes | openssl rsa`
 
     # AuthZ Settings
     tokenExtraction:

--- a/configs/authentication/stackhawk-auth-azure-ad-client-credentials-certificate.yml
+++ b/configs/authentication/stackhawk-auth-azure-ad-client-credentials-certificate.yml
@@ -1,4 +1,5 @@
-# -- stackhawk configuration for Azure Active Directory Client Credentials grant type --
+# stackhawk configuration for Azure Active Directory Client Credentials grant type with a certificate
+# https://learn.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-client-creds-grant-flow#second-case-access-token-request-with-a-certificate
 
 app:
   applicationId: ${HAWK_APP_ID}
@@ -10,19 +11,19 @@ app:
   autoInputVectors: true
 
   authentication:
-    loggedInIndicator: ".*"   # This will always match, so we will never fall through to loggedOutIndicator
-    loggedOutIndicator: "^$"  # This will never match, so we will never reauthenticate
+    loggedInIndicator: ".*" # This will always match, so we will never fall through to loggedOutIndicator
+    loggedOutIndicator: "^$" # This will never match, so we will never reauthenticate
 
     # AuthN Settings
     script:
       name: azure-ad-client-credential-certificate.kts
       parameters:
         tenant: ${AAD_TENANT} # The directory tenant that you want to log the user into. The tenant can be in GUID or friendly name format
-        scope: ${AAD_SCOPE}   # A space-separated list of scopes, or permissions, that the app requires
-        cert_thumbprint : ${AAD_CERT_THUMBPRINT} # 	Base64url-encoded SHA-1 thumbprint of the X.509 certificate's DER encoding. For example, given an X.509 certificate hash of 84E05C1D98BCE3A5421D225B140B36E86A3D5534 (Hex), the x5t claim would be hOBcHZi846VCHSJbFAs26Go9VTQ (Base64url).
+        scope: ${AAD_SCOPE} # The resource identifier (application ID URI) of the resource you want, affixed with the .default suffix, e.g. https://graph.microsoft.com/.default
+        cert_thumbprint : ${AAD_CERT_THUMBPRINT} # Base64url-encoded SHA-1 thumbprint of the X.509 certificate's DER encoding. For example, given an X.509 certificate hash of 84E05C1D98BCE3A5421D225B140B36E86A3D5534 (Hex), the x5t claim would be hOBcHZi846VCHSJbFAs26Go9VTQ (Base64url).
         cert_path: /path/to/cert
       credentials:
-        clientId: ${AAD_CLIENT_ID}          # The Application (client) ID that the Azure portal App registrations page assigned to your app
+        clientId: ${AAD_CLIENT_ID} # The Application (client) ID that the Azure portal App registrations page assigned to your app
 
     # AuthZ Settings
     tokenExtraction:

--- a/configs/authentication/stackhawk-auth-azure-ad-client-credentials-certificate.yml
+++ b/configs/authentication/stackhawk-auth-azure-ad-client-credentials-certificate.yml
@@ -1,0 +1,43 @@
+# -- stackhawk configuration for Azure Active Directory Client Credentials grant type --
+
+app:
+  applicationId: ${HAWK_APP_ID}
+  env: Development
+  host: http://localhost:3000
+  openApiConf:
+    filePath: openapi.yml
+  autoPolicy: true
+  autoInputVectors: true
+
+  authentication:
+    loggedInIndicator: ".*"   # This will always match, so we will never fall through to loggedOutIndicator
+    loggedOutIndicator: "^$"  # This will never match, so we will never reauthenticate
+
+    # AuthN Settings
+    script:
+      name: azure-ad-client-credential-certificate.kts
+      parameters:
+        tenant: ${AAD_TENANT} # The directory tenant that you want to log the user into. The tenant can be in GUID or friendly name format
+        scope: ${AAD_SCOPE}   # A space-separated list of scopes, or permissions, that the app requires
+        cert_thumbprint : ${AAD_CERT_THUMBPRINT} # 	Base64url-encoded SHA-1 thumbprint of the X.509 certificate's DER encoding. For example, given an X.509 certificate hash of 84E05C1D98BCE3A5421D225B140B36E86A3D5534 (Hex), the x5t claim would be hOBcHZi846VCHSJbFAs26Go9VTQ (Base64url).
+      credentials:
+        clientId: ${AAD_CLIENT_ID}          # The Application (client) ID that the Azure portal App registrations page assigned to your app
+
+    # AuthZ Settings
+    tokenExtraction:
+      type: TOKEN_PATH
+      value: access_token
+    tokenAuthorization:
+      type: HEADER
+      value: Authorization
+      tokenType: Bearer
+    testPath:
+      path: /secured
+      success: '.*200.*'
+
+hawkAddOn:
+  scripts:
+    - name: azure-ad-client-credential-certificate.kts
+      path: hawkscripts
+      type: authentication
+      language: KOTLIN

--- a/configs/authentication/stackhawk-auth-azure-ad-client-credentials-certificate.yml
+++ b/configs/authentication/stackhawk-auth-azure-ad-client-credentials-certificate.yml
@@ -20,6 +20,7 @@ app:
         tenant: ${AAD_TENANT} # The directory tenant that you want to log the user into. The tenant can be in GUID or friendly name format
         scope: ${AAD_SCOPE}   # A space-separated list of scopes, or permissions, that the app requires
         cert_thumbprint : ${AAD_CERT_THUMBPRINT} # 	Base64url-encoded SHA-1 thumbprint of the X.509 certificate's DER encoding. For example, given an X.509 certificate hash of 84E05C1D98BCE3A5421D225B140B36E86A3D5534 (Hex), the x5t claim would be hOBcHZi846VCHSJbFAs26Go9VTQ (Base64url).
+        cert_path: /path/to/cert
       credentials:
         clientId: ${AAD_CLIENT_ID}          # The Application (client) ID that the Azure portal App registrations page assigned to your app
 

--- a/configs/authentication/stackhawk-auth-azure-ad-client-credentials-certificate.yml
+++ b/configs/authentication/stackhawk-auth-azure-ad-client-credentials-certificate.yml
@@ -20,7 +20,7 @@ app:
       parameters:
         tenant: ${AAD_TENANT} # The directory tenant that you want to log the user into. The tenant can be in GUID or friendly name format
         scope: ${AAD_SCOPE} # The resource identifier (application ID URI) of the resource you want, affixed with the .default suffix, e.g. https://graph.microsoft.com/.default
-        cert_path: /path/to/cert # Path to the certificate file in PEM format, e.g. `openssl pkcs12 -in {yourfile.pfx} -clcerts -nokeys -out yourcert.pem`
+        cert_path: certfile.pem # Path to the certificate file in PEM format, e.g. `openssl pkcs12 -in {yourfile.pfx} -clcerts -nokeys -out yourcert.pem`
       credentials:
         clientId: ${AAD_CLIENT_ID} # The Application (client) ID that the Azure portal App registrations page assigned to your app
         pem_key: ${PEM_KEY} # The client key in PEM format, e.g. `openssl pkcs12 -in {yourfile.pfx} -nocerts -nodes | openssl rsa`

--- a/configs/authentication/stackhawk-auth-azure-ad-client-credentials-certificate.yml
+++ b/configs/authentication/stackhawk-auth-azure-ad-client-credentials-certificate.yml
@@ -18,12 +18,12 @@ app:
     script:
       name: azure-ad-client-credential-certificate.kts
       parameters:
+        cert_path: path/to/certfile.pem # Path to the certificate file in PEM format, e.g. `openssl pkcs12 -in {yourSigningCert.pfx} -clcerts -nokeys -out yourcert.pem`
         tenant: ${AAD_TENANT} # The directory tenant that you want to log the user into. The tenant can be in GUID or friendly name format
-        scope: ${AAD_SCOPE} # The resource identifier (application ID URI) of the resource you want, affixed with the .default suffix, e.g. https://graph.microsoft.com/.default
-        cert_path: certfile.pem # Path to the certificate file in PEM format, e.g. `openssl pkcs12 -in {yourfile.pfx} -clcerts -nokeys -out yourcert.pem`
+#        scope: ${AAD_SCOPE} # OPTIONAL resource identifier (application ID URI), affixed with the .default suffix, e.g. https://graph.microsoft.com/.default
       credentials:
         clientId: ${AAD_CLIENT_ID} # The Application (client) ID that the Azure portal App registrations page assigned to your app
-        pem_key: ${PEM_KEY} # The client key in PEM format, e.g. `openssl pkcs12 -in {yourfile.pfx} -nocerts -nodes | openssl rsa`
+        pem_key: ${AAD_PEM_KEY} # The client key in PEM format, e.g. `openssl pkcs12 -in {yourSigningCert.pfx} -nocerts -nodes | openssl rsa`
 
     # AuthZ Settings
     tokenExtraction:

--- a/configs/authentication/stackhawk-auth-azure-ad-client-credentials.yml
+++ b/configs/authentication/stackhawk-auth-azure-ad-client-credentials.yml
@@ -1,4 +1,5 @@
-# -- stackhawk configuration for Azure Active Directory Client Credentials grant type --
+# stackhawk configuration for Azure Active Directory Client Credentials grant type with a shared secret
+# https://learn.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-client-creds-grant-flow#first-case-access-token-request-with-a-shared-secret
 
 app:
   applicationId: ${HAWK_APP_ID}
@@ -10,18 +11,18 @@ app:
   autoInputVectors: true
 
   authentication:
-    loggedInIndicator: ".*"   # This will always match, so we will never fall through to loggedOutIndicator
-    loggedOutIndicator: "^$"  # This will never match, so we will never reauthenticate
+    loggedInIndicator: ".*" # This will always match, so we will never fall through to loggedOutIndicator
+    loggedOutIndicator: "^$" # This will never match, so we will never reauthenticate
 
     # AuthN Settings
     script:
       name: azure-ad-client-credentials.kts
       parameters:
         tenant: ${AAD_TENANT} # The directory tenant that you want to log the user into. The tenant can be in GUID or friendly name format
-        scope: ${AAD_SCOPE}   # A space-separated list of scopes, or permissions, that the app requires
+        scope: ${AAD_SCOPE} # The resource identifier (application ID URI) of the resource you want, affixed with the .default suffix, e.g. https://graph.microsoft.com/.default
       credentials:
-        clientId: ${AAD_CLIENT_ID}          # The Application (client) ID that the Azure portal App registrations page assigned to your app
-        clientSecret: ${AAD_CLIENT_SECRET}  # The client secret that you generated for your app in the app registration portal
+        clientId: ${AAD_CLIENT_ID} # The Application (client) ID that the Azure portal App Registrations page assigned to your app
+        clientSecret: ${AAD_CLIENT_SECRET} # The client secret that you generated for your app in the app registration portal
 
     # AuthZ Settings
     tokenExtraction:

--- a/scripts/examples/authentication/azure-ad-client-credential-certificate.kts
+++ b/scripts/examples/authentication/azure-ad-client-credential-certificate.kts
@@ -50,8 +50,8 @@ fun authenticate(
 
     val baseUrl = "https://login.microsoftonline.com"
     val tenant = paramsValues["tenant"]
-    val scope = paramsValues["scope"]
     val clientId = credentials.getParam("clientId")
+    val scope = paramsValues["scope"] ?: "api://${clientId}/.default"
     val grantType = "client_credentials"
     val certPath = paramsValues["cert_path"]
     val openidConfigEndpoint = "${baseUrl}/${tenant}/v2.0/.well-known/openid-configuration"
@@ -90,10 +90,9 @@ fun getRequiredParamsNames(): Array<String> {
     /**
      * @return
      *      tenant: The directory tenant that you want to log the user into. The tenant can be in GUID or friendly name format
-     *      scope: The resource identifier (application ID URI) of the resource you want, affixed with the .default suffix, e.g. https://graph.microsoft.com/.default
      *      cert_path: Path to the certificate file in PEM format, e.g. `openssl pkcs12 -in {yourfile.pfx} -clcerts -nokeys -out yourcert.pem`
      */
-    return arrayOf("tenant", "scope", "cert_path")
+    return arrayOf("tenant", "cert_path")
 }
 
 // The required credential parameters, your script will throw an error if these are not supplied in the script.credentials configuration.
@@ -109,7 +108,12 @@ fun getCredentialsParamsNames(): Array<String> {
 
 // Add these optional parameters to your HawkScan configuration file under app.authentication.script.parameters.
 fun getOptionalParamsNames(): Array<String> {
-    return arrayOf()
+    /**
+     * @return
+     *      scope: The resource identifier (application ID URI) of the resource you want, affixed with the .default
+     *          suffix, e.g. https://graph.microsoft.com/.default
+     */
+    return arrayOf("scope")
 }
 
 

--- a/scripts/examples/authentication/azure-ad-client-credential-certificate.kts
+++ b/scripts/examples/authentication/azure-ad-client-credential-certificate.kts
@@ -91,10 +91,7 @@ fun getRequiredParamsNames(): Array<String> {
      * @return
      *      tenant: The directory tenant that you want to log the user into. The tenant can be in GUID or friendly name format
      *      scope: The resource identifier (application ID URI) of the resource you want, affixed with the .default suffix, e.g. https://graph.microsoft.com/.default
-     *      cert_thumbprint: Base64url-encoded SHA-1 thumbprint of the X.509 certificate's DER encoding. For example, given
-     *          an X.509 certificate hash of 84E05C1D98BCE3A5421D225B140B36E86A3D5534 (Hex), the x5t claim would be
-     *          hOBcHZi846VCHSJbFAs26Go9VTQ (Base64url).
-     *      cert_path: Path to the file containing the signing certificate with private key for signing the client assertion
+     *      cert_path: Path to the certificate file in PEM format, e.g. `openssl pkcs12 -in {yourfile.pfx} -clcerts -nokeys -out yourcert.pem`
      */
     return arrayOf("tenant", "scope", "cert_path")
 }
@@ -105,6 +102,7 @@ fun getCredentialsParamsNames(): Array<String> {
     /**
      * @return
      *      clientId: The Application (client) ID that the Azure portal - App Registrations page assigned to your app
+     *      pem_key: The client key in PEM format, e.g. `openssl pkcs12 -in {yourfile.pfx} -nocerts -nodes | openssl rsa`
      */
     return arrayOf("clientId", "pem_key")
 }


### PR DESCRIPTION
Adds an authentication script and example StackHawk config file for the MS Entra (Azure AD) client-credentials grant type with certificate ([MS docs](https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-client-creds-grant-flow#second-case-access-token-request-with-a-certificate)).

![complicated](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExODg4dnF4djV4M3ZuZnVwdGc0NWFhbXM0NHUwbjl6d25oZnRyNmdoeCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/xwPaabcYMs6kP1Czu3/giphy.gif)