### PR TITLE
Update stackhawk-troubleshooting.yml

### DIFF
--- a/configs/httpsender/stackhawk-troubleshooting.yml
+++ b/configs/httpsender/stackhawk-troubleshooting.yml
@@ -1,4 +1,4 @@
-hawkAddOns:
+hawkAddOn:
   scripts:
     - language: KOTLIN
       #if you change the filename, you have to change a variable in code to match


### PR DESCRIPTION
fixed a typo in the config example: hawkAddOns ---> hawkAddOn.   Oddly, this typo did not cause the parser to throw an error.