### PR TITLE
Add an example session script for passing an authZ token as a query param

### DIFF
--- a/configs/session/stackhawk-query-token.yml
+++ b/configs/session/stackhawk-query-token.yml
@@ -12,11 +12,10 @@
 # (e.g., ?token=abc123) rather than headers or cookies
 
 app:
-  applicationId: 'b253978c-4f15-48c4-a0be-39369e4f0b43'
+  applicationId: 'your-app-id-here'     # ✏️ Change to your StackHawk application ID
   env: 'Development'
-  host: 'https://qa.drcsurveys.com'
-  scanPolicy:
-    name: MY_PRODSAFE
+  host: 'https://localhost:9000'        # ✏️ Change to your target application URL
+
   authentication:
     # Define success/failure indicators for authorization status
     loggedInIndicator: "HTTP/[0-9]+.[0-9]+\\s+([2-3][0-9][0-9])"  # Check app response on every request for this pattern
@@ -24,21 +23,21 @@ app:
     
     # Initial authentication using API credentials
     usernamePassword:
-      type: JSON                              # Send credentials as JSON payload
-      loginPath: /subaruweb/main/drcsurveysapi/api/authenticate
-      usernameField: User                     # JSON field name for username
-      passwordField: Password                 # JSON field name for password
-      scanUsername: ${SCAN_USERNAME}          # Environment variable for API key
-      scanPassword: ${SCAN_PASSWORD}          # Environment variable for secret
+      type: JSON                        # Send credentials as JSON payload
+      loginPath: /api/v1/auth/login     # API endpoint for login
+      usernameField: User               # JSON field name for username
+      passwordField: Password           # JSON field name for password
+      scanUsername: ${SCAN_USERNAME}    # Environment variable for username
+      scanPassword: ${SCAN_PASSWORD}    # Environment variable for password
     
     # Custom session script to handle token extraction and injection
     sessionScript:
-      name: query-token-session.kts           # References the Kotlin script below
+      name: query-token-session.kts     # References the Kotlin script below
     
     # Test endpoint to verify authentication is working
     testPath:
-      path: /api/v1/profile                   # Example protected endpoint
-      success: "HTTP.*200.*"                  # Accept 200 OK as test success
+      path: /api/v1/profile             # Example protected endpoint
+      success: "HTTP.*200.*"            # Accept 200 OK as test success
 
 # Session script configuration
 #
@@ -49,7 +48,7 @@ app:
 # 4. Automatically appends the token as a query parameter to all scan requests
 hawkAddOn:
   scripts:
-    - name: query-token-session.kts           # Script filename, found at ./hawkscripts/session/query-token-session.kts
-      path: hawkscripts                       # Base directory: ./hawkscripts
-      type: session                           # Script type: ./hawkscripts/session
-      language: KOTLIN                        # Kotlin script language
+    - name: query-token-session.kts     # Script filename, found at ./hawkscripts/session/query-token-session.kts
+      path: hawkscripts                 # Base directory: ./hawkscripts
+      type: session                     # Script type: ./hawkscripts/session
+      language: KOTLIN                  # Kotlin script language

--- a/configs/session/stackhawk-query-token.yml
+++ b/configs/session/stackhawk-query-token.yml
@@ -1,0 +1,55 @@
+# StackHawk Query Token Session Example
+# 
+# This configuration demonstrates how to set up a credentialed scan for applications
+# that require a session token to be injected as a query parameter on every request.
+# 
+# Authentication Flow:
+# 1. Initial login using target API JSON endpoint for username/password credentials
+# 2. Session script extracts token from login response
+# 3. Token is automatically appended as query parameter to all subsequent requests
+#
+# Use Case: Applications where authorization is handled via query parameters
+# (e.g., ?token=abc123) rather than headers or cookies
+
+app:
+  applicationId: 'b253978c-4f15-48c4-a0be-39369e4f0b43'
+  env: 'Development'
+  host: 'https://qa.drcsurveys.com'
+  scanPolicy:
+    name: MY_PRODSAFE
+  authentication:
+    # Define success/failure indicators for authorization status
+    loggedInIndicator: "HTTP/[0-9]+.[0-9]+\\s+([2-3][0-9][0-9])"  # Check app response on every request for this pattern
+    loggedOutIndicator: "HTTP/[0-9]+.[0-9]+\\s+(4[0-9][0-9])"     # Check for this pattern if loggedInIndicator fails
+    
+    # Initial authentication using API credentials
+    usernamePassword:
+      type: JSON                              # Send credentials as JSON payload
+      loginPath: /subaruweb/main/drcsurveysapi/api/authenticate
+      usernameField: User                     # JSON field name for username
+      passwordField: Password                 # JSON field name for password
+      scanUsername: ${SCAN_USERNAME}          # Environment variable for API key
+      scanPassword: ${SCAN_PASSWORD}          # Environment variable for secret
+    
+    # Custom session script to handle token extraction and injection
+    sessionScript:
+      name: query-token-session.kts           # References the Kotlin script below
+    
+    # Test endpoint to verify authentication is working
+    testPath:
+      path: /api/v1/profile                   # Example protected endpoint
+      success: "HTTP.*200.*"                  # Accept 200 OK as test success
+
+# Session script configuration
+#
+# The query-token-session.kts script performs the following:
+# 1. Intercepts the authentication response
+# 2. Extracts the session token from the JSON response
+# 3. Stores the token for use in subsequent requests
+# 4. Automatically appends the token as a query parameter to all scan requests
+hawkAddOn:
+  scripts:
+    - name: query-token-session.kts           # Script filename, found at ./hawkscripts/session/query-token-session.kts
+      path: hawkscripts                       # Base directory: ./hawkscripts
+      type: session                           # Script type: ./hawkscripts/session
+      language: KOTLIN                        # Kotlin script language

--- a/scripts/examples/session/query-token-session.kts
+++ b/scripts/examples/session/query-token-session.kts
@@ -1,0 +1,120 @@
+// HawkScan Session Script for Token-Based Authentication via Query Parameters
+// This script manages session tokens by extracting them from authentication responses
+// and automatically adding them as query parameters to subsequent requests
+
+import org.apache.log4j.LogManager
+import com.stackhawk.hste.session.ScriptBasedSessionManagementMethodType
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
+import org.parosproxy.paros.network.HtmlParameter
+
+// Initialize logger for debugging session management operations
+val logger = LogManager.getLogger("query-token-session")
+logger.info("Query Token Session script (query-token-session.kts) loaded successfully.")
+
+// JSON parser for extracting token from authentication response
+val mapper = ObjectMapper()
+
+/**
+ * Session Extraction Function
+ * 
+ * Called after authentication to establish a session. Extracts the authentication token
+ * from the JSON response body and stores it for use in subsequent requests.
+ * 
+ * The sessionWrapper provides access to:
+ * - httpMessage.responseBody: JSON response containing the token
+ * - httpMessage.responseHeader: HTTP headers from auth response
+ * - httpMessage.requestingUser: User making the authenticated request
+ * 
+ * @param sessionWrapper Contains the authentication response data
+ */
+fun extractWebSession(sessionWrapper: ScriptBasedSessionManagementMethodType.SessionWrapper) {
+    val responseBody = sessionWrapper.httpMessage.responseBody
+    logger.info("Got authentication response:\n${responseBody}")
+    
+    // Parse JSON response to extract the token field
+    val authResponseObject = mapper.readValue(sessionWrapper.httpMessage.responseBody.bytes, ObjectNode::class.java)
+    val token = authResponseObject.get("Token").asText()
+    logger.info("Extracted authorization session token from authN response:\ntoken = $token")
+    
+    // Store token in session for use by processMessageToMatchSession()
+    sessionWrapper.session.setValue("token", token)
+}
+
+/**
+ * Request Modification Function
+ * 
+ * Called for each outgoing request to modify it before sending to the web application.
+ * This function automatically adds the authentication token as a query parameter to
+ * maintain the authenticated session state.
+ * 
+ * Process:
+ * 1. Retrieves the stored session token
+ * 2. Removes any existing "token" query parameter to avoid duplicates
+ * 3. Adds the current session token as a URL query parameter
+ * 4. Updates the request with modified parameters
+ * 
+ * @param sessionWrapper Contains the outgoing HTTP request to be modified
+ */
+fun processMessageToMatchSession(sessionWrapper: ScriptBasedSessionManagementMethodType.SessionWrapper) {
+    // Get the session token that was stored during authentication
+    val sessionToken = sessionWrapper.session.getValue("token").toString()
+    val queryParams = sessionWrapper.httpMessage.urlParams
+    
+    // Remove any existing token parameter to prevent duplicates
+    if (queryParams.find { it.name == "token" } != null) {
+        queryParams.removeIf { it.name == "token" }
+    }
+    
+    // Add the current session token as a query parameter
+    queryParams.add(HtmlParameter(HtmlParameter.Type.url, "token", sessionToken))
+    
+    // Apply the updated parameters to the request
+    sessionWrapper.httpMessage.requestHeader.setGetParams(queryParams)
+}
+
+/**
+ * Session Cleanup Function
+ * 
+ * Called internally when a new session is required, typically after session expiry
+ * or logout. This function should clear any stored session identifiers to prepare
+ * for a fresh authentication cycle.
+ * 
+ * Note: This implementation is empty as token cleanup is handled automatically
+ * when a new token is extracted during re-authentication.
+ * 
+ * @param sessionWrapper Contains the session data to be cleared
+ */
+fun clearWebSessionIdentifiers(sessionWrapper: ScriptBasedSessionManagementMethodType.SessionWrapper) {
+    // No explicit cleanup needed - session token will be overwritten on next auth
+}
+
+/**
+ * Required Parameters Configuration
+ * 
+ * Defines the parameter names that must be provided in the stackhawk.yml configuration
+ * under sessionScript.parameters. The script will fail to load if these are missing.
+ * 
+ * This script currently requires no external parameters as it extracts all needed
+ * information from the authentication response.
+ * 
+ * @return Array of required parameter names (empty for this script)
+ */
+fun getRequiredParamsNames(): Array<String> {
+    return arrayOf()
+}
+
+/**
+ * Optional Parameters Configuration
+ * 
+ * Defines the parameter names that can optionally be provided in the stackhawk.yml
+ * configuration under sessionScript.optionalParameters. The script will not fail
+ * if these parameters are missing.
+ * 
+ * This script currently uses no optional parameters.
+ * 
+ * @return Array of optional parameter names (empty for this script)
+ */
+fun getOptionalParamsNames(): Array<String> {
+    return arrayOf()
+}


### PR DESCRIPTION
This PR adds a new session script which extracts a token, "Token," from a StackHawk JSON authentication response and passes is it as a query parameter for authorization.

<img width="1536" height="1024" alt="heresTheKey" src="https://github.com/user-attachments/assets/87095ab0-2cd9-4533-9f1f-661950e20aa7" />
